### PR TITLE
Rename Stack to data

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -3,28 +3,28 @@ import request from 'superagent'
 let userToken
 const apiDomain = process.env.REACT_APP_API_DOMAIN
 
-const Stack = {
+const data = {
   setUserToken: (token) => {
     userToken = token
   },
-  all: () => {
+  getStacks: () => {
     return request.get(`${apiDomain}/api/stacks`)
       .set('Authorization', `Bearer ${userToken}`)
       .then(res => res.body.stacks)
   },
-  get: (id) => {
+  getStack: (id) => {
     return request.get(`${apiDomain}/api/stacks/${id}`)
       .set('Authorization', `Bearer ${userToken}`)
       .then(res => res.body)
   },
-  save: (stack) => {
+  saveStack: (stack) => {
     if (!stack.id) {
-      return Stack.create(stack)
+      return data.createStack(stack)
     } else {
-      return Stack.update(stack)
+      return data.updateStack(stack)
     }
   },
-  create: (stack) => {
+  createStack: (stack) => {
     return request.post(`${apiDomain}/api/stacks`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({ title: stack.title })
@@ -33,7 +33,7 @@ const Stack = {
         return Object.assign({}, stack, createdStack)
       })
   },
-  update: (stack) => {
+  updateStack: (stack) => {
     return request.put(`${apiDomain}/api/stacks/${stack.id}`)
       .set('Authorization', `Bearer ${userToken}`)
       .send({ title: stack.title })
@@ -42,7 +42,7 @@ const Stack = {
         return Object.assign({}, stack, updatedStack)
       })
   },
-  delete: (stackOrId) => {
+  deleteStack: (stackOrId) => {
     let stackId = stackOrId
     if (typeof stackOrId !== 'string') {
       stackId = stackOrId.id
@@ -59,4 +59,4 @@ const Stack = {
   }
 }
 
-export default Stack
+export default data

--- a/src/data.test.js
+++ b/src/data.test.js
@@ -1,9 +1,9 @@
 /* globals test, expect */
 
-import Stack from './Stack'
+import data from './data'
 import nock from 'nock'
 
-Stack.setUserToken(process.env.REACT_APP_USER_TOKEN)
+data.setUserToken(process.env.REACT_APP_USER_TOKEN)
 
 test('can retrieve list of stacks', (done) => {
   nock(process.env.REACT_APP_API_DOMAIN)
@@ -17,7 +17,7 @@ test('can retrieve list of stacks', (done) => {
       ]
     })
 
-  Stack.all().then(stacks => {
+  data.getStacks().then(stacks => {
     expect(stacks).toHaveLength(1)
     expect(stacks[0].title).toBe('Interview questions')
     done()
@@ -33,7 +33,7 @@ test('can create a stack', (done) => {
     })
 
   const stack = { title: 'New stack' }
-  Stack.save(stack).then(stack => {
+  data.saveStack(stack).then(stack => {
     expect(stack.id).toBe('bde')
     done()
   })
@@ -47,7 +47,7 @@ test('can get a stack', (done) => {
       title: 'Test stack'
     })
 
-  Stack.get('bde').then(stack => {
+  data.getStack('bde').then(stack => {
     expect(stack.id).toBe('bde')
     expect(stack.title).toBe('Test stack')
     done()
@@ -69,13 +69,15 @@ test('can update a stack', (done) => {
       title: 'Updated title'
     })
 
-  Stack.get('bde').then(stack => {
-    stack.title = 'Updated title'
-    Stack.save(stack).then(stack => {
+  data.getStack('bde')
+    .then(stack => {
+      stack.title = 'Updated title'
+      return data.saveStack(stack)
+    })
+    .then(stack => {
       expect(stack.title).toBe('Updated title')
       done()
     })
-  })
 })
 
 test('can delete a stack', (done) => {
@@ -86,7 +88,7 @@ test('can delete a stack', (done) => {
     })
 
   const stack = { id: 'bde', title: 'Test stack' }
-  Stack.delete(stack).then(deleted => {
+  data.deleteStack(stack).then(deleted => {
     expect(deleted).toBe(true)
     done()
   })


### PR DESCRIPTION
It doesn't make sense to have to set the user token for stacks
and cards, or to put card methods in Stack. Let's use a data
object instead and have it have methods for stacks and cards.